### PR TITLE
fix copyFont

### DIFF
--- a/app/tasks/build.js
+++ b/app/tasks/build.js
@@ -268,8 +268,8 @@ gulp.task('copyImages', function () {
 });
 
 gulp.task('copyFonts', function () {
-  return gulp.src(env.folders.temp + '/app/fonts')
-    .pipe(gulp.dest(env.folders.build));
+  return gulp.src(env.folders.app + '/fonts/**/*.*')
+    .pipe(gulp.dest(env.folders.build + '/fonts'));
 });
 
 gulp.task('copyIcons', function () {


### PR DESCRIPTION
minimal fix, copy fonts to dist/fonts when invoking `fj build`